### PR TITLE
Feat/reservation/kafka

### DIFF
--- a/airbnb/reservation/build.gradle
+++ b/airbnb/reservation/build.gradle
@@ -22,6 +22,11 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation group: 'org.modelmapper', name: 'modelmapper', version: '2.3.8'
+    implementation 'org.springframework.kafka:spring-kafka'
+//    implementation 'org.springframework.cloud:spring-cloud-starter-stream-kafka'
+
+    testImplementation 'org.springframework.kafka:spring-kafka-test'
+
     compileOnly group: 'com.fasterxml.jackson.core', name: 'jackson-databind'
     compileOnly group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-jsr310'
     compileOnly 'org.projectlombok:lombok'

--- a/airbnb/reservation/src/main/java/com/example/reservation/controller/ReservationController.java
+++ b/airbnb/reservation/src/main/java/com/example/reservation/controller/ReservationController.java
@@ -40,10 +40,10 @@ public class ReservationController {
 
     }
 
-    @PostMapping("/cancel/{id}")
-    ResponseEntity<ResponseReservation> cancel(@PathVariable("id") Long id){
+    @PostMapping("/cancel/{rvId}")
+    ResponseEntity<ResponseReservation> cancel(@PathVariable("rvId") Long rvId){
 
-        ResponseReservation responseReservation = reservationServiceInterface.cancel(id);
+        ResponseReservation responseReservation = reservationServiceInterface.cancel(rvId);
 
         return new ResponseEntity(responseReservation, HttpStatus.OK);
     }

--- a/airbnb/reservation/src/main/java/com/example/reservation/controller/ReservationController.java
+++ b/airbnb/reservation/src/main/java/com/example/reservation/controller/ReservationController.java
@@ -2,6 +2,7 @@ package com.example.reservation.controller;
 
 import com.example.reservation.dto.ReservationDto;
 import com.example.reservation.persistence.Reservation;
+import com.example.reservation.persistence.Status;
 import com.example.reservation.service.ReservationServiceInterface;
 import com.example.reservation.vo.RequestReservation;
 import com.example.reservation.vo.ResponseReservation;
@@ -32,8 +33,7 @@ public class ReservationController {
         ReservationDto reservationDto = new ModelMapper().map(requestReservation,ReservationDto.class);
 //        지금은 Dto에 setter로 reserving 상태로 넣어주는데,
 //        생성자를 통해 자동 reserving 되는걸로 추후에 수정하기
-        Reservation.Status status = Reservation.Status.RESERVING;
-        reservationDto.setStatus(status);
+        reservationDto.setStatus(Status.RESERVING);
         ResponseReservation responseReservation = reservationServiceInterface.reserve(reservationDto);
 
         return new ResponseEntity(responseReservation, HttpStatus.CREATED);

--- a/airbnb/reservation/src/main/java/com/example/reservation/dto/ReservationDto.java
+++ b/airbnb/reservation/src/main/java/com/example/reservation/dto/ReservationDto.java
@@ -1,6 +1,7 @@
 package com.example.reservation.dto;
 
 import com.example.reservation.persistence.Reservation;
+import com.example.reservation.persistence.Status;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
@@ -11,11 +12,10 @@ import java.time.LocalDateTime;
 @NoArgsConstructor
 public class ReservationDto {
 
-//    private String rvId;
 
     private Long roomId;
 
-    private Reservation.Status status;
+    private Status status;
 
     private Integer numOfPeople;
 

--- a/airbnb/reservation/src/main/java/com/example/reservation/event/ReservationCanceled.java
+++ b/airbnb/reservation/src/main/java/com/example/reservation/event/ReservationCanceled.java
@@ -1,7 +1,0 @@
-package com.example.reservation.event;
-
-import lombok.Data;
-
-@Data
-public class ReservationCanceled {
-}

--- a/airbnb/reservation/src/main/java/com/example/reservation/event/ReservationCancelled.java
+++ b/airbnb/reservation/src/main/java/com/example/reservation/event/ReservationCancelled.java
@@ -1,0 +1,10 @@
+package com.example.reservation.event;
+
+import lombok.Data;
+
+@Data
+public class ReservationCancelled {
+    private long id;
+    private Integer price;
+
+}

--- a/airbnb/reservation/src/main/java/com/example/reservation/event/ReservationCancelled.java
+++ b/airbnb/reservation/src/main/java/com/example/reservation/event/ReservationCancelled.java
@@ -4,7 +4,8 @@ import lombok.Data;
 
 @Data
 public class ReservationCancelled {
-    private long id;
+    private Long id;
+    private Long payId;
     private Integer price;
 
 }

--- a/airbnb/reservation/src/main/java/com/example/reservation/event/ReservationCancelled.java
+++ b/airbnb/reservation/src/main/java/com/example/reservation/event/ReservationCancelled.java
@@ -4,7 +4,7 @@ import lombok.Data;
 
 @Data
 public class ReservationCancelled {
-    private Long id;
+    private Long rvId;
     private Long payId;
     private Integer price;
 

--- a/airbnb/reservation/src/main/java/com/example/reservation/event/ReservationCreated.java
+++ b/airbnb/reservation/src/main/java/com/example/reservation/event/ReservationCreated.java
@@ -6,7 +6,7 @@ import java.util.Date;
 
 @Data
 public class ReservationCreated {
-    private long id;
+    private long rvId;
     private Integer price;
 
 }

--- a/airbnb/reservation/src/main/java/com/example/reservation/messagequeue/KafkaConsumer.java
+++ b/airbnb/reservation/src/main/java/com/example/reservation/messagequeue/KafkaConsumer.java
@@ -40,7 +40,8 @@ public class KafkaConsumer {
             ex.printStackTrace();
         }
 
-        Optional<Reservation> reservationOptional = repository.findById( (Long) map.get("rvId") );
+        Long tempRvId = ((Number)map.get("rvId") ).longValue();
+        Optional<Reservation> reservationOptional = repository.findById( tempRvId);
         if (reservationOptional.isPresent()) {
             Reservation reservation = reservationOptional.get();
             reservation.setStatus(Status.RESERVED);
@@ -71,7 +72,8 @@ public class KafkaConsumer {
         }catch (JsonProcessingException ex ){
             ex.printStackTrace();
         }
-        Optional<Reservation> reservationOptional = repository.findById( (Long) map.get("rvId") );
+        Long tempRvId = ((Number)map.get("rvId") ).longValue();
+        Optional<Reservation> reservationOptional = repository.findById(tempRvId);
         if (reservationOptional.isPresent()) {
             repository.delete(reservationOptional.get());
         }

--- a/airbnb/reservation/src/main/java/com/example/reservation/messagequeue/KafkaConsumer.java
+++ b/airbnb/reservation/src/main/java/com/example/reservation/messagequeue/KafkaConsumer.java
@@ -1,0 +1,84 @@
+package com.example.reservation.messagequeue;
+
+
+import com.example.reservation.persistence.Reservation;
+import com.example.reservation.persistence.ReservationRepository;
+import com.example.reservation.persistence.Status;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Service;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+@Service
+@Slf4j
+public class KafkaConsumer {
+
+    ReservationRepository repository;
+
+    @Autowired
+    public KafkaConsumer(ReservationRepository repository) {
+        this.repository = repository;
+    }
+
+    @KafkaListener(topics = "PaymentApproved")
+    public void confirmReserve(String kafkaMessage) {
+        log.info("consumer received event from topics(PaymentApproved) : "+ kafkaMessage);
+        Map<Object, Object> map = new HashMap<>();
+        ObjectMapper mapper = new ObjectMapper();
+        try{
+            map = mapper.readValue(kafkaMessage, new TypeReference<Map<Object, Object>>() {
+            });
+
+        }catch (JsonProcessingException ex ){
+            ex.printStackTrace();
+        }
+
+        Optional<Reservation> reservationOptional = repository.findById( (Long) map.get("rvId") );
+        if (reservationOptional.isPresent()) {
+            Reservation reservation = reservationOptional.get();
+            reservation.setStatus(Status.RESERVED);
+            repository.save(reservation);
+        }
+        else{
+            log.info("rvId:"+ (Long)map.get("rvId") + "does not exists");
+        }
+
+
+    }
+
+
+    @KafkaListener(topics = "PaymentCancelled")
+    public void confirmCancel(String kafkaMessage){
+        
+//        굳이 토픽을 두개만들지말고 PaymentApproved이벤트인지 Cancel이벤트인지 구별해주는 변수값 추가하여
+//        하나의 리스너에서 조건문을 통해 로직을 구현할것인가?
+//        아니면 지금처럼 리스너 두개를 만들어서 로직을 구현할 것 인가?
+        log.info("consumer received event from topics(PaymentCancelled) : "+ kafkaMessage);
+        Map<Object, Object> map = new HashMap<>();
+        ObjectMapper mapper = new ObjectMapper();
+
+        try{
+            map = mapper.readValue(kafkaMessage, new TypeReference<Map<Object, Object>>() {
+            });
+
+        }catch (JsonProcessingException ex ){
+            ex.printStackTrace();
+        }
+        Optional<Reservation> reservationOptional = repository.findById( (Long) map.get("rvId") );
+        if (reservationOptional.isPresent()) {
+            repository.delete(reservationOptional.get());
+        }
+        else{
+            log.info("rvId:"+ (Long)map.get("rvId") + "does not exists");
+        }
+        
+        
+    }
+}

--- a/airbnb/reservation/src/main/java/com/example/reservation/messagequeue/KafkaConsumerConfig.java
+++ b/airbnb/reservation/src/main/java/com/example/reservation/messagequeue/KafkaConsumerConfig.java
@@ -1,0 +1,41 @@
+package com.example.reservation.messagequeue;
+
+
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.annotation.EnableKafka;
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+import org.springframework.kafka.core.ConsumerFactory;
+import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@EnableKafka
+@Configuration
+public class KafkaConsumerConfig {
+    @Bean
+    public ConsumerFactory<String, String> consumerFactory() {
+        Map<String ,Object> properties = new HashMap<>();
+        properties.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, "127.0.0.1:9092");
+        properties.put(ConsumerConfig.GROUP_ID_CONFIG, "consumerGroupId");
+        properties.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        properties.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+
+        return new DefaultKafkaConsumerFactory<>(properties);
+    }
+
+    @Bean
+    public ConcurrentKafkaListenerContainerFactory<String , String> kafkaListenerContainerFactory(){
+
+        ConcurrentKafkaListenerContainerFactory <String,String> kafkaListenerContainerFactory
+                = new ConcurrentKafkaListenerContainerFactory<>();
+        kafkaListenerContainerFactory.setConsumerFactory(consumerFactory());
+
+        return kafkaListenerContainerFactory;
+
+    }
+
+}

--- a/airbnb/reservation/src/main/java/com/example/reservation/messagequeue/KafkaProducer.java
+++ b/airbnb/reservation/src/main/java/com/example/reservation/messagequeue/KafkaProducer.java
@@ -1,0 +1,39 @@
+package com.example.reservation.messagequeue;
+
+
+import com.example.reservation.event.ReservationCancelled;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Service;
+
+@Service
+@Slf4j
+public class KafkaProducer {
+    private KafkaTemplate<String ,String> kafkaTemplate;
+
+    @Autowired
+    public KafkaProducer(KafkaTemplate<String, String> kafkaTemplate) {
+        this.kafkaTemplate = kafkaTemplate;
+    }
+
+
+    public ReservationCancelled send(String topic, ReservationCancelled reservationCancelled) {
+        ObjectMapper mapper = new ObjectMapper();
+        String jsonInString = "";
+        try{
+            jsonInString = mapper.writeValueAsString(reservationCancelled);
+
+        }catch (JsonProcessingException ex){
+            ex.printStackTrace();
+
+        }
+        kafkaTemplate.send(topic, jsonInString);
+        log.info("Kafka Producer send " + reservationCancelled);
+
+        return reservationCancelled;
+    }
+
+}

--- a/airbnb/reservation/src/main/java/com/example/reservation/messagequeue/KafkaProducerConfig.java
+++ b/airbnb/reservation/src/main/java/com/example/reservation/messagequeue/KafkaProducerConfig.java
@@ -1,0 +1,34 @@
+package com.example.reservation.messagequeue;
+
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.annotation.EnableKafka;
+import org.springframework.kafka.core.DefaultKafkaProducerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.core.ProducerFactory;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@EnableKafka
+@Configuration
+public class KafkaProducerConfig {
+//    빈을 등록할예정
+//    1. 접속할수 있는 카프카의 정보
+    @Bean
+    public ProducerFactory<String, String> producerFactory() {
+        Map<String ,Object> properties = new HashMap<>();
+        properties.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, "127.0.0.1:9092");
+        properties.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        properties.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+
+        return new DefaultKafkaProducerFactory<>(properties);
+    }
+
+    @Bean
+    public KafkaTemplate<String, String> kafkaTemplate(){
+        return new KafkaTemplate<>(producerFactory());
+    }
+}

--- a/airbnb/reservation/src/main/java/com/example/reservation/persistence/Reservation.java
+++ b/airbnb/reservation/src/main/java/com/example/reservation/persistence/Reservation.java
@@ -20,7 +20,7 @@ public class Reservation extends BaseTimeEntity{
 
     @Id
     @GeneratedValue(strategy= GenerationType.IDENTITY)
-    private Long id;
+    private Long rvId;
 
     @Column(nullable = false)
     private Long roomId;

--- a/airbnb/reservation/src/main/java/com/example/reservation/persistence/Reservation.java
+++ b/airbnb/reservation/src/main/java/com/example/reservation/persistence/Reservation.java
@@ -27,10 +27,6 @@ public class Reservation extends BaseTimeEntity{
 
     private Long payId;
 
-    public enum Status{
-        RESERVING, RESERVED;
-    }
-
     @Column(nullable = false)
     private Integer numOfPeople;
 

--- a/airbnb/reservation/src/main/java/com/example/reservation/persistence/ReservationRepository.java
+++ b/airbnb/reservation/src/main/java/com/example/reservation/persistence/ReservationRepository.java
@@ -2,9 +2,11 @@ package com.example.reservation.persistence;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
 
 
 public interface ReservationRepository extends JpaRepository<Reservation,Long> {
 
 
+    Optional<Reservation> findByRvId(Long rvId);
 }

--- a/airbnb/reservation/src/main/java/com/example/reservation/persistence/Status.java
+++ b/airbnb/reservation/src/main/java/com/example/reservation/persistence/Status.java
@@ -1,0 +1,5 @@
+package com.example.reservation.persistence;
+
+public enum Status {
+    RESERVING, RESERVED;
+}

--- a/airbnb/reservation/src/main/java/com/example/reservation/service/ReservationServiceImpl.java
+++ b/airbnb/reservation/src/main/java/com/example/reservation/service/ReservationServiceImpl.java
@@ -58,9 +58,9 @@ public class ReservationServiceImpl implements ReservationServiceInterface {
 
     @Override
     @Transactional
-    public ResponseReservation cancel(Long id){
+    public ResponseReservation cancel(Long rvId){
 
-        Optional<Reservation> reservationOptional = reservationRepository.findById(id);
+        Optional<Reservation> reservationOptional = reservationRepository.findByRvId(rvId);
 
         if (reservationOptional.isPresent()){
             Reservation reservation = reservationOptional.get();

--- a/airbnb/reservation/src/main/java/com/example/reservation/service/ReservationServiceImpl.java
+++ b/airbnb/reservation/src/main/java/com/example/reservation/service/ReservationServiceImpl.java
@@ -1,12 +1,12 @@
 package com.example.reservation.service;
 
 import com.example.reservation.dto.ReservationDto;
-import com.example.reservation.event.ReservationCanceled;
+import com.example.reservation.event.ReservationCancelled;
 import com.example.reservation.event.ReservationCreated;
+import com.example.reservation.messagequeue.KafkaProducer;
 import com.example.reservation.persistence.Reservation;
 import com.example.reservation.persistence.ReservationRepository;
 import com.example.reservation.vo.ResponseReservation;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.modelmapper.ModelMapper;
 import org.modelmapper.convention.MatchingStrategies;
@@ -15,8 +15,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Optional;
-import java.util.UUID;
-import java.util.regex.Matcher;
 
 @Service
 @Slf4j
@@ -24,12 +22,14 @@ public class ReservationServiceImpl implements ReservationServiceInterface {
 
 
     private final ReservationRepository reservationRepository;
-//    payment 마이크로서비스에 대한 의존성 추가
+    private final KafkaProducer kafkaProducer;
+    //    payment 마이크로서비스에 대한 의존성 추가
 
 
     @Autowired
-    public ReservationServiceImpl(ReservationRepository reservationRepository) {
+    public ReservationServiceImpl(ReservationRepository reservationRepository , KafkaProducer kafkaProducer) {
         this.reservationRepository = reservationRepository;
+        this.kafkaProducer = kafkaProducer;
     }
 
     @Override
@@ -64,10 +64,14 @@ public class ReservationServiceImpl implements ReservationServiceInterface {
 
         if (reservationOptional.isPresent()){
             Reservation reservation = reservationOptional.get();
-            ReservationCanceled reservationCanceled = new ModelMapper().map(reservation,ReservationCanceled.class);
-//            예약취소이벤트 발행하고 Payment의 cancel메소드를 비동기호출한다.
-//            추후 결제취소 이벤트를 발행받으면 해당 예약 레코드를 최종삭제한다.
+            ReservationCancelled reservationCancelled = new ModelMapper().map(reservation, ReservationCancelled.class);
+
+//          발행한 예약취소이벤트를 kafkaProducer가 메세지 큐에 보낸다.
+            kafkaProducer.send("ReservationCancelled", reservationCancelled);
+            log.info("Kafka Producer send to topics(ReservationCancelled)" + reservationCancelled );
+
             ResponseReservation responseReservation = new ModelMapper().map(reservation,ResponseReservation.class);
+
             return  responseReservation;
         }
 

--- a/airbnb/reservation/src/main/java/com/example/reservation/service/ReservationServiceInterface.java
+++ b/airbnb/reservation/src/main/java/com/example/reservation/service/ReservationServiceInterface.java
@@ -6,5 +6,5 @@ import com.example.reservation.vo.ResponseReservation;
 public interface ReservationServiceInterface {
 
     public ResponseReservation reserve(ReservationDto reservationDto);
-    public ResponseReservation cancel(Long id);
+    public ResponseReservation cancel(Long rvId);
 }

--- a/airbnb/reservation/src/main/java/com/example/reservation/vo/ResponseReservation.java
+++ b/airbnb/reservation/src/main/java/com/example/reservation/vo/ResponseReservation.java
@@ -12,7 +12,7 @@ import java.util.Date;
 @Data
 public class ResponseReservation {
 
-    private Long id;
+    private Long rvId;
 
     private Integer roomId;
 

--- a/airbnb/reservation/src/main/java/com/example/reservation/vo/ResponseReservation.java
+++ b/airbnb/reservation/src/main/java/com/example/reservation/vo/ResponseReservation.java
@@ -1,6 +1,7 @@
 package com.example.reservation.vo;
 
 import com.example.reservation.persistence.Reservation;
+import com.example.reservation.persistence.Status;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import lombok.Data;
 
@@ -15,7 +16,7 @@ public class ResponseReservation {
 
     private Integer roomId;
 
-    private Reservation.Status status;
+    private Status status;
 
     private Integer numOfPeople;
 

--- a/airbnb/reservation/src/main/resources/application.yml
+++ b/airbnb/reservation/src/main/resources/application.yml
@@ -22,3 +22,11 @@ spring:
     ddl-auto: create-drop
     show-sql: true
     defer-datasource-initialization: true
+  kafka:
+    bootstrap-servers: localhost:9092
+    consumer:
+      group-id: myGroup
+      enable-auto-commit: false
+      auto-offset-reset: latest
+    listener:
+      ack-mode: manual

--- a/airbnb/reservation/src/main/resources/application.yml
+++ b/airbnb/reservation/src/main/resources/application.yml
@@ -12,7 +12,7 @@ spring:
       enabled: true
 
   datasource:
-    url: jdbc:h2:~/test
+    url: jdbc:h2:~/test2
     driver-class-name: org.h2.Driver
     username: sa
 


### PR DESCRIPTION
## Related Issue

Resolve : #18 

## Description
Spring Kafka을 이용한 Reservation 서비스의 비동기통신 구현

## Discussion
1. 토픽이름을 이벤트명으로 정했는데.. 다른분들은 어떻게 하셨나용
2. 이벤트랑 토픽이 1:1 매핑관계로 설정해서 그런지 KafkaConsumer의 리스너 메소드 코드가 서비스 호출부분말고는 중복되었는데..  다른분들은 어떻게 하셨는지 궁금합니다..( Payment관련 이벤트들이 하나의 토픽으로 전부 발행되고 소비되면 어떨지 생각해봤는데.. 어떤게 더 좋은지 모르겠네요...)